### PR TITLE
pax-app/Wiki#199 Fixing route token validation

### DIFF
--- a/project/api/views.py
+++ b/project/api/views.py
@@ -85,7 +85,7 @@ def user_login():
 
 # Logout for access
 @users_blueprint.route('/auth/logout', methods=['GET'])
-def user_logout(resp):
+def user_logout():
     response_object = {
         'status': 'success',
         'message': 'Successfully logged out.'
@@ -94,6 +94,7 @@ def user_logout(resp):
 
 
 @users_blueprint.route('/auth/status', methods=['GET'])
+@authenticate
 def get_user_status(resp):
     user = UserModel.query.filter_by(user_id=resp).first()
     auth_token = user.encode_auth_token(user.user_id)
@@ -106,7 +107,7 @@ def get_user_status(resp):
 
 # Provider Registration Route
 @users_blueprint.route('/provider_registration', methods=['POST'])
-def provider_registration(resp):
+def provider_registration():
     post_data = request.json
 
     if(not request.is_json or not post_data):


### PR DESCRIPTION
# Descrição
* Removendo argumento esperado nos metodos de logout e virar provider, o argumento era necessário antes quando a autenticação era feita no serviço e não na gateway, exceto pelo serviço de status, esse deve continuar autenticado pois é usado na autenticação da gateway.

# Issue Relacionada

Relacionado a issue pax-app/Wiki#199, porem não a resolve.

# Tipo de Mudanças

- [ ] História de Usuário
- [X] Historia Técnica
- [ ] Wiki

# Responsáveis pela revisão

@esiofreitas (PO)
@lucasdutraf (PO)
@(Membro do time de desenvolvimento que não esteja envolvido do PR)
